### PR TITLE
Unquote the url sent by profile server to get proper username

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 /env
 /IXProfileClient.egg-info
+.idea/

--- a/ixprofile_client/pipeline.py
+++ b/ixprofile_client/pipeline.py
@@ -8,6 +8,7 @@ from django.http import HttpResponseRedirect
 from social.exceptions import AuthFailed
 
 import re
+import urllib
 
 from ixprofile_client.webservice import UserWebService
 
@@ -33,7 +34,7 @@ def match_user(strategy, details, response, uid, *args, **kwargs):
     match = re.match('^%sid/u/(.+)$' % settings.PROFILE_SERVER, uid)
 
     if match:
-        username = match.group(1)
+        username = urllib.unquote(match.group(1))
         try:
             # user is known to us
             user = User.objects.get(username=username)


### PR DESCRIPTION
I tested this in shell_plus and it decodes the string properly, so, this should fix the problem.
