### PR TITLE
ValueError is raised when removing a non-existant element from a list.

### DIFF
--- a/ixprofile_client/steps.py
+++ b/ixprofile_client/steps.py
@@ -500,8 +500,11 @@ class MockProfileServer(webservice.UserWebService):
         user = self.users[details['email']]
         user['groups'] = list(set(user.get('groups', [])) - set(groups))
 
-        for group in groups:
-            self.groups.setdefault(group, []).remove(details['email'])
+        try:
+            for group in groups:
+                self.groups.setdefault(group, []).remove(details['email'])
+        except ValueError:
+            pass
 
         return user['groups']
 


### PR DESCRIPTION
A common occurence when your list is empty.
