### PR TITLE
Store last_login in ISO format

### DIFF
--- a/ixprofile_client/steps.py
+++ b/ixprofile_client/steps.py
@@ -324,7 +324,8 @@ def create_login_cookie(self, email, minutes):
 
     auth_handler.login_as_user(user)
 
-    webservice.profile_server.set_details(user, last_login=user.last_login)
+    webservice.profile_server.set_details(
+        user, last_login=user.last_login.isoformat())
 
     self.given('I visit site page ""')
     self.given('I left my computer for {0} minutes'.format(minutes))


### PR DESCRIPTION
The real profile server returns dates as ISO 8601 strings, so the mock should mimic that.