### PR TITLE
Fix password reset URL

### DIFF
--- a/ixprofile_client/webservice.py
+++ b/ixprofile_client/webservice.py
@@ -215,7 +215,7 @@ class UserWebService(object):
 
         response = self._request(
             'POST',
-            urljoin(self._detail_uri(user.username), 'reset-password'),
+            urljoin(self._detail_uri(user.username), 'reset-password/'),
         )
         self._raise_for_failure(response)
 


### PR DESCRIPTION
Tastypie URLs require a trailing slash