### PR TITLE
Fix broken login by ensuring the cookie is set

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+source = ixprofile_client
+
+[report]
+omit = ixprofile_client/steps.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,17 @@ python:
     - "3.4"
     - "3.5"
 env:
-    - DJANGO="django>=1.7,<1.8"
     - DJANGO="django>=1.8,<1.9"
     - DJANGO="django>=1.9,<1.10"
     - DJANGO="django>=1.10,<1.11"
 matrix:
     exclude:
-        - python: "3.5"
-          env: DJANGO="django>=1.7,<1.8"
         - python: "3.3"
           env: DJANGO="django>=1.9,<1.10"
         - python: "3.3"
           env: DJANGO="django>=1.10,<1.11"
 install:
+    - pip install -U pip
     - pip install $DJANGO
     - pip install -r requirements.txt
     - pip install -r test_requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django >= 1.6
-furl >= 0.3.95
+Django>=1.8,<1.10
+furl>=0.3.95
 future
-python-social-auth >= 0.1.20
-requests >= 2.3.0
+python-social-auth>=0.1.20
+requests>=2.3.0


### PR DESCRIPTION
1) The cookie *must* set the domain, and it must be the same as the
   browser's domain.
2) Setting the cookie always causes an exception with Selenium 2.1.13,
   even when it's successful - see
   https://github.com/ariya/phantomjs/issues/14047